### PR TITLE
Adding a timeout of 4s to the readiness probe so that /__gtg

### DIFF
--- a/helm/draft-content-suggestions/templates/deployment.yaml
+++ b/helm/draft-content-suggestions/templates/deployment.yaml
@@ -55,6 +55,6 @@ spec:
             port: 8080
           initialDelaySeconds: 15
           periodSeconds: 30
+          timeoutSeconds: 4
         resources:
 {{ toYaml .Values.resources | indent 12 }}
-


### PR DESCRIPTION
... will timeout before the probe does.