### PR TITLE
Automatically recreating RUNBOOK.md without relationships [Skip CI]

### DIFF
--- a/runbooks/runbook.md
+++ b/runbooks/runbook.md
@@ -1,3 +1,7 @@
+<!--
+    Written in the format prescribed by https://github.com/Financial-Times/runbook.md.
+    Any future edits should abide by this format.
+-->
 # PAC - Draft Content Suggestions API
 
 Retrieves suggestions from UPP for draft CMS content.
@@ -18,22 +22,6 @@ Bronze
 
 Production
 
-## Delivered By
-
-content
-
-## Supported By
-
-content
-
-## Known About By
-
-- elitsa.pavlova
-- kalin.arsov
-- ivan.nikolov
-- miroslav.gatsanoga
-- hristo.georgiev
-
 ## Host Platform
 
 AWS
@@ -42,7 +30,7 @@ AWS
 
 The PAC Draft Content Suggestions API reads draft CMS content from the PAC Draft Content Public Read service, retrieves annotation suggestions for it using the UPP Public Suggestions API and returns them to the consumer.
 
-PAC architecture diagram: https://user-images.githubusercontent.com/3042889/74439601-3aa12180-4e75-11ea-8625-a933bf33ea54.png
+PAC architecture diagram: <https://user-images.githubusercontent.com/3042889/74439601-3aa12180-4e75-11ea-8625-a933bf33ea54.png>
 
 ## Contains Personal Data
 
@@ -52,10 +40,19 @@ No
 
 No
 
-## Dependencies
+<!-- Placeholder - remove HTML comment markers to activate
+## Can Download Personal Data
+Choose Yes or No
 
-- draft-content-public-read
-- public-suggestions-api
+...or delete this placeholder if not applicable to this system
+-->
+
+<!-- Placeholder - remove HTML comment markers to activate
+## Can Contact Individuals
+Choose Yes or No
+
+...or delete this placeholder if not applicable to this system
+-->
 
 ## Failover Architecture Type
 
@@ -72,7 +69,7 @@ FullyAutomated
 ## Failover Details
 
 The service is deployed in both PAC clusters. The failover guide is located here:
-https://github.com/Financial-Times/upp-docs/tree/master/failover-guides/pac-cluster
+<https://github.com/Financial-Times/upp-docs/tree/master/failover-guides/pac-cluster>
 
 ## Data Recovery Process Type
 
@@ -94,6 +91,14 @@ Manual
 
 The service is a member of the "annotations-curation" health category so a PAC cluster failover is required during release.
 
+<!-- Placeholder - remove HTML comment markers to activate
+## Heroku Pipeline Name
+Enter descriptive text satisfying the following:
+This is the name of the Heroku pipeline for this system. If you don't have a pipeline, this is the name of the app in Heroku. A pipeline is a group of Heroku apps that share the same codebase where each app in a pipeline represents the different stages in a continuous delivery workflow, i.e. staging, production.
+
+...or delete this placeholder if not applicable to this system
+-->
+
 ## Key Management Process Type
 
 Manual
@@ -106,12 +111,13 @@ To rotate credentials you need to login to a particular cluster and update varni
 ## Monitoring
 
 Service in the PAC K8S clusters:
-- PAC-Prod-EU health: https://pac-prod-eu.upp.ft.com/__health/__pods-health?service-name=draft-content-suggestions
-- PAC-Prod-US health: https://pac-prod-us.upp.ft.com/__health/__pods-health?service-name=draft-content-suggestions
+
+*   PAC-Prod-EU health: <https://pac-prod-eu.upp.ft.com/__health/__pods-health?service-name=draft-content-suggestions>
+*   PAC-Prod-US health: <https://pac-prod-us.upp.ft.com/__health/__pods-health?service-name=draft-content-suggestions>
 
 ## First Line Troubleshooting
 
-https://github.com/Financial-Times/upp-docs/tree/master/guides/ops/first-line-troubleshooting
+<https://github.com/Financial-Times/upp-docs/tree/master/guides/ops/first-line-troubleshooting>
 
 ## Second Line Troubleshooting
 


### PR DESCRIPTION

## What
 - The [RUNBOOK.md](https://github.com/Financial-Times/draft-content-suggestions/blob/runbook-no-relationships-2021-03-19/runbooks/runbook.md) file has been automatically regenerated from the Biz Ops data for the **draft-content-suggestions** system.
 - All the relationships/dependencies have been excluded from RUNBOOK.md but are still in the **draft-content-suggestions** system in [Biz Ops](https://biz-ops.in.ft.com/System/draft-content-suggestions).
 - Please continue to manage those relationships/dependencies manually or via the Biz Ops API.

## Why
 - Support for relationships/dependencies within RUNBOOK.md is being removed to avoid the side effects [identified in this proposal](https://docs.google.com/document/d/1njFceyb49TeaIR53Y9r62CenTzdey1fyeJkUvxd9SQQ)
 - This is a prerequisite to the improved ownership/support model [defined in this proposal](https://docs.google.com/document/d/1vTRe7S5dUqIMAoWyqD2pMEkg_5998NCEeFwsxT_k9pw).

## Next Steps
 - Please check and merge this PR.
 - You should only see the removal of the **Delivered By**, **Supported By**, **Technical Owner**, **Known About By**, **Stakeholders**, **Dependencies** and **Healthcheck** sections. Please contact [#reliability-eng](https://financialtimes.slack.com/archives/C07B3043U) if there are other differences as your current runbook.md file may be inconsistent with Biz Ops.
 - [Reliability Engineering](https://financialtimes.slack.com/archives/C07B3043U) are unlocking all the relationships/dependencies to re-enable manual/API updates.
 - [Reliability Engineering](https://financialtimes.slack.com/archives/C07B3043U) are adjusting the rules to allow these simpler RUNBOOK.md files to pass validation.
