### PR TITLE
Send additional 'X-Origin' header when calling Suggestion Umbrella

### DIFF
--- a/mocks/mocks.go
+++ b/mocks/mocks.go
@@ -132,6 +132,11 @@ func NewUmbrellaTestServer(healthy bool) *httptest.Server {
 
 		switch r.URL.Path {
 		case "/content/suggest":
+			if r.Header.Get("X-Origin") != "PAC" {
+				w.WriteHeader(http.StatusBadRequest)
+				w.Write([]byte(`{ message: "Request has invalid 'Origin' header" }`))
+				return
+			}
 			if !healthy {
 				w.WriteHeader(http.StatusInternalServerError)
 				return

--- a/suggestions/suggestions.go
+++ b/suggestions/suggestions.go
@@ -10,7 +10,11 @@ import (
 	"github.com/Financial-Times/draft-content-suggestions/commons"
 )
 
-const APIKeyHeader = "X-Api-Key"
+const (
+	APIKeyHeader = "X-Api-Key"
+	OriginHeader = "X-Origin"
+	Origin       = "PAC"
+)
 
 func NewUmbrellaAPI(endpoint string, gtgEndpoint string, apiKey string, httpClient *http.Client, healthHTTPClient *http.Client) (UmbrellaAPI, error) {
 	umbrellaAPI := &umbrellaAPI{endpoint, gtgEndpoint, apiKey, httpClient, healthHTTPClient}
@@ -48,6 +52,7 @@ func (u *umbrellaAPI) FetchSuggestions(ctx context.Context, content []byte) (sug
 	}
 
 	req.Header.Set(APIKeyHeader, u.apiKey)
+	req.Header.Set(OriginHeader, Origin)
 
 	res, err := u.httpClient.Do(req)
 	if err != nil {


### PR DESCRIPTION
# Description

Send additional 'X-Origin' header when calling Suggestion Umbrella

The header will be used in `ontotext-suggestions-api` to distinguish requests coming from PAC.

## What

I've used prefix 'X' for the header key in order to be consistent with other custom headers we've got.

## Why

[JIRA](https://financialtimes.atlassian.net/browse/UPPSF-3061)

## Scope and particulars of this PR (Please tick all that apply)

- [ ] Tech hygiene (dependency updating & other tech debt)
- [ ] Bug fix
- [ ] Feature
- [ ] Documentation
- [ ] Breaking change
- [X] Minor change (e.g. fixing a typo, adding config)

___
This Pull Request follows the rules described in our [Pull Requests Guide](https://github.com/Financial-Times/upp-docs/tree/master/guides/pr-guide)
