### PR TITLE
migrate requests to basicAuth

### DIFF
--- a/draft/draft_content.go
+++ b/draft/draft_content.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"strings"
 
@@ -72,7 +72,7 @@ func (d *draftContentAPI) FetchDraftContent(ctx context.Context, uuid string) ([
 		return nil, fmt.Errorf("error in draft content retrival status=%v", response.StatusCode)
 	}
 
-	bytes, err := ioutil.ReadAll(response.Body)
+	bytes, err := io.ReadAll(response.Body)
 	if err != nil {
 		return nil, err
 	}

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/Financial-Times/draft-content-suggestions
 
-go 1.17
+go 1.21
 
 require (
 	github.com/Financial-Times/api-endpoint v1.0.0

--- a/handler_test.go
+++ b/handler_test.go
@@ -61,7 +61,7 @@ func handleTestRequest(urlpath string) (resp *http.Response, err error) {
 
 	log := logger.NewUPPLogger("Test", "PANIC")
 	contentAPI, _ := draft.NewContentAPI(draftContentTestServer.URL+"/drafts/content", draftContentTestServer.URL+"/__gtg", http.DefaultClient, http.DefaultClient)
-	umbrellaAPI, _ := suggestions.NewUmbrellaAPI(umbrellaTestServer.URL, umbrellaTestServer.URL+"/__gtg", "12345", http.DefaultClient, http.DefaultClient)
+	umbrellaAPI, _ := suggestions.NewUmbrellaAPI(umbrellaTestServer.URL, umbrellaTestServer.URL+"/__gtg", suggestions.TestUsername, suggestions.TestPassword, http.DefaultClient, http.DefaultClient)
 
 	rh := requestHandler{contentAPI, umbrellaAPI, log}
 

--- a/helm/draft-content-suggestions/templates/deployment.yaml
+++ b/helm/draft-content-suggestions/templates/deployment.yaml
@@ -45,11 +45,11 @@ spec:
             configMapKeyRef:
               name: global-config
               key: upp-suggestions-umbrella-gtg-endpoint
-        - name: SUGGESTIONS_API_KEY
+        - name: DELIVERY_BASIC_AUTH
           valueFrom:
             secretKeyRef:
               name: doppler-global-secrets
-              key: DRAFT_CONTENT_SUGGESTIONS_UPP_SUGGESTIONS_UMBRELLA_API_KEY
+              key: UPP_DELIVERY_CLUSTER_BASIC_AUTH
         - name: LOG_LEVEL
           value: INFO
         ports:

--- a/main.go
+++ b/main.go
@@ -5,6 +5,7 @@ import (
 	"net/http"
 	"os"
 	"os/signal"
+	"strings"
 	"syscall"
 	"time"
 
@@ -70,21 +71,21 @@ func main() {
 	})
 	suggestionsEndpoint := app.String(cli.StringOpt{
 		Name:   "suggestions-umbrella-endpoint",
-		Value:  "http://test.api.ft.com/content/suggest",
+		Value:  "https://upp-staging-delivery-glb.upp.ft.com/content/suggest",
 		Desc:   "Endpoint for Suggestions Umbrella",
 		EnvVar: "SUGGESTIONS_ENDPOINT",
 	})
 	suggestionsGtgEndpoint := app.String(cli.StringOpt{
 		Name:   "suggestions-umbrella-gtg-endpoint",
-		Value:  "http://test.api.ft.com/content/suggest/__gtg",
+		Value:  "https://upp-staging-delivery-glb.upp.ft.com/content/suggest/__gtg",
 		Desc:   "Endpoint for Suggestions Umbrella",
 		EnvVar: "SUGGESTIONS_GTG_ENDPOINT",
 	})
-	suggestionsAPIKey := app.String(cli.StringOpt{
-		Name:   "suggestions-api-key",
-		Value:  "",
-		Desc:   "API key to access Suggestions Umbrella",
-		EnvVar: "SUGGESTIONS_API_KEY",
+	deliveryBasicAuth := app.String(cli.StringOpt{
+		Name:   "delivery-basic-auth",
+		Value:  "username:password",
+		Desc:   "Basic auth for access to the delivery UPP clusters",
+		EnvVar: "DELIVERY_BASIC_AUTH",
 	})
 	logLevel := app.String(cli.StringOpt{
 		Name:   "log-level",
@@ -121,7 +122,12 @@ func main() {
 			return
 		}
 
-		umbrellaAPI, err := suggestions.NewUmbrellaAPI(*suggestionsEndpoint, *suggestionsGtgEndpoint, *suggestionsAPIKey, loggingCl, healthCl)
+		basicAuthCredentials := strings.Split(*deliveryBasicAuth, ":")
+		if len(basicAuthCredentials) != 2 {
+			log.Fatal("error while resolving basic auth")
+		}
+
+		umbrellaAPI, err := suggestions.NewUmbrellaAPI(*suggestionsEndpoint, *suggestionsGtgEndpoint, basicAuthCredentials[0], basicAuthCredentials[1], loggingCl, healthCl)
 		if err != nil {
 			log.WithError(err).Error("Suggestions Umbrella API error, exiting ...")
 			return

--- a/mocks/mocks.go
+++ b/mocks/mocks.go
@@ -1,12 +1,10 @@
 package mocks
 
 import (
-	"encoding/base64"
 	"encoding/json"
 	"io"
 	"net/http"
 	"net/http/httptest"
-	"strings"
 )
 
 const ValidMockContentUUID = "6f14ea94-690f-3ed4-98c7-b926683c735a"
@@ -127,8 +125,16 @@ func NewDraftContentTestServer(healthy bool) *httptest.Server {
 
 func NewUmbrellaTestServer(healthy bool) *httptest.Server {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if basicAuth := r.Header.Get(AuthorizationHeader); basicAuth != createBasicAuth("username", "password") {
+		username, password, ok := r.BasicAuth()
+		if !ok {
 			w.WriteHeader(http.StatusUnauthorized)
+			_, _ = w.Write([]byte("unauthorized"))
+			return
+		}
+
+		if username != "username" || password != "password" {
+			w.WriteHeader(http.StatusUnauthorized)
+			_, _ = w.Write([]byte("unauthorized"))
 			return
 		}
 
@@ -171,8 +177,4 @@ func NewUmbrellaTestServer(healthy bool) *httptest.Server {
 	}))
 
 	return server
-}
-
-func createBasicAuth(testUsername string, testPassword string) string {
-	return "Basic " + base64.StdEncoding.EncodeToString([]byte(strings.Join([]string{testUsername, testPassword}, ":")))
 }

--- a/suggestions/suggestions_test.go
+++ b/suggestions/suggestions_test.go
@@ -13,13 +13,11 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-const apiKey = "12345"
-
 func TestUmbrellaAPI_IsGTGSuccess(t *testing.T) {
 	testServer := mocks.NewUmbrellaTestServer(true)
 	defer testServer.Close()
 
-	umbrellaAPI, err := NewUmbrellaAPI(testServer.URL+"/content/suggest", testServer.URL+"/content/suggest/__gtg", apiKey, http.DefaultClient, http.DefaultClient)
+	umbrellaAPI, err := NewUmbrellaAPI(testServer.URL+"/content/suggest", testServer.URL+"/content/suggest/__gtg", TestUsername, TestPassword, http.DefaultClient, http.DefaultClient)
 	assert.NoError(t, err)
 
 	msg, err := umbrellaAPI.IsGTG(context.Background())
@@ -31,7 +29,7 @@ func TestUmbrellaAPI_IsGTGFailure503(t *testing.T) {
 	testServer := mocks.NewUmbrellaTestServer(false)
 	defer testServer.Close()
 
-	umbrellaAPI, err := NewUmbrellaAPI(testServer.URL+"/content/suggest", testServer.URL+"/content/suggest/__gtg", apiKey, http.DefaultClient, http.DefaultClient)
+	umbrellaAPI, err := NewUmbrellaAPI(testServer.URL+"/content/suggest", testServer.URL+"/content/suggest/__gtg", TestUsername, TestPassword, http.DefaultClient, http.DefaultClient)
 	assert.NoError(t, err)
 
 	_, err = umbrellaAPI.IsGTG(context.Background())
@@ -42,7 +40,7 @@ func TestUmbrellaAPI_IsGTGFailureInvalidEndpoint(t *testing.T) {
 	testServer := mocks.NewUmbrellaTestServer(false)
 	defer testServer.Close()
 
-	umbrellaAPI, err := NewUmbrellaAPI(testServer.URL+"/content/suggest", ":#", apiKey, http.DefaultClient, http.DefaultClient)
+	umbrellaAPI, err := NewUmbrellaAPI(testServer.URL+"/content/suggest", ":#", TestUsername, TestPassword, http.DefaultClient, http.DefaultClient)
 	assert.NoError(t, err)
 
 	_, err = umbrellaAPI.IsGTG(context.Background())
@@ -56,7 +54,7 @@ func TestUmbrellaAPI_IsGTGFailureRequestError(t *testing.T) {
 	testServer := mocks.NewUmbrellaTestServer(false)
 	defer testServer.Close()
 
-	umbrellaAPI, err := NewUmbrellaAPI(testServer.URL+"/content/suggest", "__gtg", apiKey, http.DefaultClient, http.DefaultClient)
+	umbrellaAPI, err := NewUmbrellaAPI(testServer.URL+"/content/suggest", "__gtg", TestUsername, TestPassword, http.DefaultClient, http.DefaultClient)
 	assert.NoError(t, err)
 
 	_, err = umbrellaAPI.IsGTG(context.Background())
@@ -72,7 +70,7 @@ func TestUmbrellaAPI_FetchSuggestions(t *testing.T) {
 	testServer := mocks.NewUmbrellaTestServer(true)
 	defer testServer.Close()
 
-	umbrellaAPI, err := NewUmbrellaAPI(testServer.URL+"/content/suggest", testServer.URL+"/content/suggest/__gtg", apiKey, http.DefaultClient, http.DefaultClient)
+	umbrellaAPI, err := NewUmbrellaAPI(testServer.URL+"/content/suggest", testServer.URL+"/content/suggest/__gtg", TestUsername, TestPassword, http.DefaultClient, http.DefaultClient)
 	assert.NoError(t, err)
 
 	suggestions, err := umbrellaAPI.FetchSuggestions(context.Background(), mockDraftContent)
@@ -83,7 +81,7 @@ func TestUmbrellaAPI_FetchDraftContentFailure(t *testing.T) {
 	testServer := mocks.NewUmbrellaTestServer(false)
 	defer testServer.Close()
 
-	contentAPI, err := NewUmbrellaAPI(testServer.URL+"/content/suggest", testServer.URL+"/content/suggest/__gtg", apiKey, http.DefaultClient, http.DefaultClient)
+	contentAPI, err := NewUmbrellaAPI(testServer.URL+"/content/suggest", testServer.URL+"/content/suggest/__gtg", TestUsername, TestPassword, http.DefaultClient, http.DefaultClient)
 	assert.NoError(t, err)
 
 	suggestions, err := contentAPI.FetchSuggestions(context.Background(), newMockDraftContent())


### PR DESCRIPTION
# Description

## What

- Migrate the service requests to hit directly `UPP Delivery Clusters` global records instead of api gateway.
- Update minor tech debt like go version and outdated `ioutil` -> `io`.
- Make sure the helm configuration is updated.

## Why

[JIRA](https://financialtimes.atlassian.net/browse/UPPSF-4661)

## Scope and particulars of this PR (Please tick all that apply)

- [ ] Tech hygiene (dependency updating & other tech debt)
- [ ] Bug fix
- [x] Feature
- [ ] Documentation
- [ ] Breaking change
- [ ] Minor change (e.g. fixing a typo, adding config)

## DoD - Ensure all relevant tasks are completed before marking this PR as "Ready for review"

- [x] Test coverage is not significantly decreased
- [x] All PR checks have passed
- [x] Changes are deployed on dev before asking for review
- [x] Documentations remains up-to-date
  - [ ] OpenAPI definition file is updated
  - [ ] README file is updated
  - [ ] Documentation is updated in upp-docs and upp-public-docs
  - [ ] Architecture diagrams are updated

___
This Pull Request follows the rules described in our [Pull Requests Guide](https://github.com/Financial-Times/upp-docs/tree/master/guides/pr-guide)
